### PR TITLE
qasync 0.27.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "qasync" %}
-{% set version = "0.23.0" %}
-{% set sha256 = "8965ec313e0107148d98e8ac1e77a77dce74de3cd97055a1aa62d513a3793a14" %}
+{% set version = "0.27.1" %}
 
 # on our builders there is no X11 installed and therefore import
 # test will fail
@@ -16,29 +15,30 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: 8dc768fd1ee5de1044c7c305eccf2d39d24d87803ea71189d4024fb475f4985f
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
-  skip: True  # [py<36]
-  skip: True  # [linux and (s390x or ppc64le)]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
+  skip: True  # [py<38 or (linux and s390x)]
 
 requirements:
   host:
     - python
     - pip
-    - setuptools
-    - wheel
+    - poetry-core >=1.5.0
   run:
     - python
 
 {% if enable_testingui %}
 test:
-  requires:
-    - pyqt
   imports:
     - qasync
+  requires:
+    - pyqt
+    - pip
+  commands:
+    - pip check
 {% endif %}
 
 about:
@@ -47,7 +47,6 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: Implementation of the PEP 3156 Event-Loop with Qt.
-
   description: |
     qasync allows coroutines to be used in PyQt/PySide applications by
     providing an implementation of the PEP 3156 event-loop.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,6 +51,7 @@ about:
     qasync allows coroutines to be used in PyQt/PySide applications by
     providing an implementation of the PEP 3156 event-loop.
   dev_url: https://github.com/CabbageDevelopment/qasync
+  doc_url: https://github.com/CabbageDevelopment/qasync
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5765](https://anaconda.atlassian.net/browse/PKG-5765)
- [Upstream repo](https://github.com/CabbageDevelopment/qasync/tree/v0.27.1)
- release-notes: https://github.com/CabbageDevelopment/qasync/releases
- release-diff: https://github.com/CabbageDevelopment/qasync/compare/v0.23.0...v0.27.1
- license: https://github.com/CabbageDevelopment/qasync/blob/master/LICENSE
- requirements-tagged:
  - https://github.com/CabbageDevelopment/qasync/blob/v0.27.1/pyproject.toml


### Explanation of changes:

- Clean up the recipe by anaconda-linter
- Skip py<38
- Use poetry-core as a build backend in host
- Add pip check

[PKG-5765]: https://anaconda.atlassian.net/browse/PKG-5765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ